### PR TITLE
Capitalise sequence

### DIFF
--- a/args/args.go
+++ b/args/args.go
@@ -6,14 +6,15 @@ import (
 )
 
 var (
-	WordCount         = flag.Int("count", 1, "amount of words to generate")
-	delimiter         = flag.String("delimiter", " ", "sequence of characters to separate words")
-	capitalise        = flag.Bool("capital", false, "words will be capitalised")
-	upperCase         = flag.Bool("upper", false, "words will be in upper case (overrides capitalisation)")
-	prefix            = flag.String("prefix", "", "output will begin with")
-	suffix            = flag.String("suffix", "", "output will end with")
-	removeApostrophes = flag.Bool("rm-apos", false, "remove apostrophes from words")
-	seenCount         int
+	WordCount          = flag.Int("count", 1, "amount of words to generate")
+	delimiter          = flag.String("delimiter", " ", "sequence of characters to separate words")
+	capitalise         = flag.Bool("capital", false, "words will be capitalised")
+	upperCase          = flag.Bool("upper", false, "words will be in upper case (overrides capitalisation)")
+	prefix             = flag.String("prefix", "", "output will begin with")
+	suffix             = flag.String("suffix", "", "output will end with")
+	removeApostrophes  = flag.Bool("rm-apos", false, "remove apostrophes from words")
+	capitaliseSequence = flag.Bool("cap-seq", false, "capitalse sequence of words")
+	seenCount          int
 )
 
 func ParseArgs() {
@@ -27,11 +28,10 @@ func ApplyArgs(word *string) {
 	if *upperCase {
 		augmented = strings.ToUpper(augmented)
 	} else {
-		retain := (augmented)[1:]
 		if *capitalise {
-			augmented = strings.ToUpper((augmented)[:1]) + retain
+			augmented = strings.ToUpper(augmented[:1]) + augmented[1:]
 		} else {
-			augmented = strings.ToLower((augmented)[:1]) + retain
+			augmented = strings.ToLower(augmented[:1]) + augmented[1:]
 		}
 	}
 
@@ -40,6 +40,9 @@ func ApplyArgs(word *string) {
 	}
 
 	if seenCount == 1 {
+		if *capitaliseSequence {
+			augmented = strings.ToUpper((augmented)[:1]) + augmented[1:]
+		}
 		augmented = *prefix + augmented
 	}
 

--- a/args/args_test.go
+++ b/args/args_test.go
@@ -72,7 +72,7 @@ func TestSuffix(t *testing.T) {
 	assertEqual(t, "wuv!", word1)
 }
 
-func TestRemoveApostrophies(t *testing.T) {
+func TestRemoveApostrophes(t *testing.T) {
 	setup()
 	*removeApostrophes = true
 	word := "lari's"
@@ -86,7 +86,7 @@ func TestCapitalisingSequence(t *testing.T) {
 	setup()
 	*capitaliseSequence = true
 	word0 := "hello"
-	word1 := "world"
+	word1 := "World"
 
 	ApplyArgs(&word0)
 	ApplyArgs(&word1)

--- a/args/args_test.go
+++ b/args/args_test.go
@@ -82,6 +82,33 @@ func TestRemoveApostrophies(t *testing.T) {
 	assertEqual(t, "laris", word)
 }
 
+func TestCapitalisingSequence(t *testing.T) {
+	setup()
+	*capitaliseSequence = true
+	word0 := "hello"
+	word1 := "world"
+
+	ApplyArgs(&word0)
+	ApplyArgs(&word1)
+
+	assertEqual(t, "Hello", word0)
+	assertEqual(t, "world", word1)
+}
+
+func TestCapitalisingSequenceIgnoresPrefix(t *testing.T) {
+	setup()
+	*prefix = ">"
+	*capitaliseSequence = true
+	word0 := "hello"
+	word1 := "world"
+
+	ApplyArgs(&word0)
+	ApplyArgs(&word1)
+
+	assertEqual(t, ">Hello", word0)
+	assertEqual(t, "world", word1)
+}
+
 func setup() {
 	*WordCount = 0
 	*delimiter = " "
@@ -90,6 +117,7 @@ func setup() {
 	*prefix = ""
 	*suffix = ""
 	*removeApostrophes = false
+	*capitaliseSequence = false
 	seenCount = 0
 }
 


### PR DESCRIPTION
Allows for the ability to create a sentence with proper capitalisation for the first word.

New flag created `-cap-seq`. Only applies mutation on the first word seen, once the capitalisations have been applied to the word.